### PR TITLE
fix: Attempt to measure component after it has been unmounted

### DIFF
--- a/src/react-middle-truncate/middle-truncate.jsx
+++ b/src/react-middle-truncate/middle-truncate.jsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { debounce, toFinite, isNumber } from 'lodash';
+import { debounce, toFinite } from 'lodash';
 import { findDOMNode } from 'react-dom';
 import PropTypes from 'prop-types';
 import measureText from './utils/measure-text';
@@ -158,11 +158,13 @@ class MiddleTruncate extends PureComponent {
 
   getComponentMeasurement = () => {
     const node = findDOMNode(this.refs.component);
-    const { offsetWidth, offsetHeight } = node;
+
+    const offsetWidth = node && node.offsetWidth ? node.offsetWidth : 0;
+    const offsetHeight = node && node.offsetHeight ? node.offsetHeight : 0;
 
     return {
-      width: isNumber(offsetWidth) ? units.parse(offsetWidth, 'px') : 0,
-      height: isNumber(offsetHeight) ? units.parse(offsetHeight, 'px') : 0
+      width: units.parse(offsetWidth, 'px'),
+      height: units.parse(offsetHeight, 'px')
     };
   }
 

--- a/src/react-middle-truncate/utils/measure-text/measure-text.js
+++ b/src/react-middle-truncate/utils/measure-text/measure-text.js
@@ -70,8 +70,8 @@ const measureHeight = (size, lineHeight) => {
 const measureText = ({
   text,
   fontFamily,
-  fontSize,
-  lineHeight,
+  fontSize = '',
+  lineHeight = 1,
   fontWeight = DEFAULT_FONT_WEIGHT,
   fontStyle = DEFAULT_FONT_STYLE,
   canvas = DEFAULT_CANVAS
@@ -84,8 +84,8 @@ const measureText = ({
       text: line,
       width: units.parse(`${ctx.measureText(line).width}px`),
       height: measureHeight(
-        units.parse(fontSize),
-        units.parse(lineHeight)
+        units.parse(fontSize, 'fontSize'),
+        units.parse(lineHeight, 'lineHeight')
       )
     };
   };


### PR DESCRIPTION
## Description

This PR fixes an issue where the `MiddleTruncate` component is unmounted, but still attempts to read the measurements of the component in order to parse the text for truncation. This scenario could occur when the `onResize` event listener was triggered, but the component was unmounted before the debounced `onResize` handler was called.

- Added sensible defaults to ensure we always return numeric values if for some reason we cannot get the measurements of the component.
- Cancel the debounced `onResize` and `parseTextForTruncation` when the component is unmounted.
