### PR TITLE
Support triple-click selections for smartCopy

### DIFF
--- a/src/react-middle-truncate/middle-truncate.jsx
+++ b/src/react-middle-truncate/middle-truncate.jsx
@@ -117,7 +117,7 @@ class MiddleTruncate extends PureComponent {
       return;
     }
 
-    const selectedText = window.getSelection().toString();
+    const selectedText = window.getSelection().toString().trim();
 
     // If smartCopy is set to partial or if smartCopy is set to all and the entire string was selected
     // copy the original full text to the user's clipboard


### PR DESCRIPTION
A triple-click selection typically results in a newline character being added to the end of the selection string, which was incompatible with how we were comparing the copied string to our known text (===). By trimming the whitespace from the selection we can ensure a correct match.

## Pull Request Checklist

- Added/updated the following to reflect my change:
	- [I can add one if you think it's needed] Unit tests
	- [N/A?] Documentation 
- Tested against the different major versions of [React][url-react]
	- [N/A? Not a react-related issue] v15.5.x
	- [N/A?] v16.x.x
- [x] Unit tests have passed.
- [x] Code linting has passed. 

[url-react]: https://reactjs.org/
